### PR TITLE
Fixed #24 Switch button display incorrect

### DIFF
--- a/__tests__/Components/__snapshots__/ChooseCoin.js.snap
+++ b/__tests__/Components/__snapshots__/ChooseCoin.js.snap
@@ -19,7 +19,7 @@ exports[`ChooseCoin Test ChooseCoin snapshot 1`] = `
         </b>
       </div>
       <div
-        className="btn-group col"
+        className="btn-group btn-group-toggle col"
         data-toggle="buttons"
       >
         <label

--- a/__tests__/Components/__snapshots__/ChooseHexagramLines.js.snap
+++ b/__tests__/Components/__snapshots__/ChooseHexagramLines.js.snap
@@ -19,7 +19,7 @@ exports[`ChooseHexagramLines Test ChooseHexagramLines snapshot 1`] = `
         </b>
       </div>
       <div
-        className="btn-group col"
+        className="btn-group btn-group-toggle col"
         data-toggle="buttons"
       >
         <label

--- a/app/Components/ChooseCoin.js
+++ b/app/Components/ChooseCoin.js
@@ -94,7 +94,7 @@ class ChooseCoin extends Component {
 
           <div className="row mb-2">
             <div className="col"><b>Line {(this.props.lineNumber * 1) + 1}</b></div>
-            <div className="btn-group col" data-toggle="buttons">
+            <div className="btn-group btn-group-toggle col" data-toggle="buttons">
               <label className="btn btn-secondary btn-sm active" htmlFor="coinMode">
                 <input type="radio" name="options" id="coinMode" autoComplete="off" defaultChecked /> Coin Mode
               </label>

--- a/app/Components/ChooseHexagramLines.js
+++ b/app/Components/ChooseHexagramLines.js
@@ -21,7 +21,7 @@ const ChooseHexagramLines = ({
 
         <div className="row mb-2">
           <div className="col"><b>Line {(lineNumber * 1) + 1}</b></div>
-          <div className="btn-group col" data-toggle="buttons">
+          <div className="btn-group btn-group-toggle col" data-toggle="buttons">
             {/** Putting onClick event on lable because FireFox, Edge, and IE's radio
               * input element does not work appropriatly to fire the click event */}
             <label role="button" tabIndex="-1" className="btn btn-outline-secondary btn-sm" htmlFor="coinMode" onClick={handleSwitchMode}>


### PR DESCRIPTION
Fixed #24 
Changed two components' classnames due to the Bootstrap v 4.0 changed radio group buttons' class name.